### PR TITLE
Update support badge to Minimal Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Logs Streamer
 
-[![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained-support)
+[![Minimal Support](https://img.shields.io/badge/Pantheon-Minimal_Support-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#minimal-support)
 
 Streams logs like a boss.
 


### PR DESCRIPTION
"Actively Maintained Support" implies that the Terminus plugin is something that users can contact support and ask questions about. As this appears to be maintained by an individual, and not @pantheon-systems/developer-experience (who own Terminus and the official plugins), and the ability to get support (via [Pantheon support channels](https://docs.pantheon.io/guides/support/contact-support/)) on the plugin is unknown, [Minimal Support](https://docs.pantheon.io/oss-support-levels#minimal-support) is actually more accurate, based on the OSS Support Levels documentation.

Additionally, as the README says "not ready for production", this implies that we should not be advertising that users can get support for the Terminus plugin.